### PR TITLE
deps: migrate container images from Bitnami to Soldevelo equivalents

### DIFF
--- a/ch10/mysql-11.1.17/values.yaml
+++ b/ch10/mysql-11.1.17/values.yaml
@@ -1154,8 +1154,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r29
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch10/mysql-12.1.0/values.yaml
+++ b/ch10/mysql-12.1.0/values.yaml
@@ -1341,8 +1341,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r33
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch11/wordpress-23.1.21/charts/mariadb/values.yaml
+++ b/ch11/wordpress-23.1.21/charts/mariadb/values.yaml
@@ -1054,8 +1054,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r30
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)

--- a/ch11/wordpress-23.1.21/charts/memcached/values.yaml
+++ b/ch11/wordpress-23.1.21/charts/memcached/values.yaml
@@ -619,8 +619,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r30
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch11/wordpress-23.1.21/values.yaml
+++ b/ch11/wordpress-23.1.21/values.yaml
@@ -893,8 +893,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r31
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch21/redis-15.6.1/my-values.yaml
+++ b/ch21/redis-15.6.1/my-values.yaml
@@ -74,8 +74,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.6-debian-10-r49
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-15.6.1/new-values.yaml
+++ b/ch21/redis-15.6.1/new-values.yaml
@@ -74,8 +74,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.6-debian-10-r49
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-15.6.1/values.yaml
+++ b/ch21/redis-15.6.1/values.yaml
@@ -74,8 +74,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.6-debian-10-r49
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.11.2/my-values.yaml
+++ b/ch21/redis-16.11.2/my-values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-10-r23
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.11.2/new-values.yaml
+++ b/ch21/redis-16.11.2/new-values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-10-r23
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.11.2/values.yaml
+++ b/ch21/redis-16.11.2/values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-10-r23
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.12.3/my-new-values.yaml
+++ b/ch21/redis-16.12.3/my-new-values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-11-r3
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.12.3/my-values.yaml
+++ b/ch21/redis-16.12.3/my-values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-11-r3
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-16.12.3/values.yaml
+++ b/ch21/redis-16.12.3/values.yaml
@@ -77,8 +77,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/redis
-  tag: 6.2.7-debian-11-r3
+  repository: soldevelo/redis
+  tag: 6.2.16-debian-12-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/ch21/redis-20.11.3/ci/values.yaml
+++ b/ch21/redis-20.11.3/ci/values.yaml
@@ -2154,8 +2154,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r38
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2287,8 +2287,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r38
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch21/redis-20.11.3/values.yaml
+++ b/ch21/redis-20.11.3/values.yaml
@@ -2154,8 +2154,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r38
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2287,8 +2287,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r38
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch21/redis-20.12.2/ci/values.yaml
+++ b/ch21/redis-20.12.2/ci/values.yaml
@@ -2156,8 +2156,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r40
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2289,8 +2289,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r40
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/ch21/redis-20.12.2/values.yaml
+++ b/ch21/redis-20.12.2/values.yaml
@@ -2156,8 +2156,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r40
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2289,8 +2289,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r40
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Dependency update: Bitnami to SolDevelo container images

Bitnami changed its container image distribution model on **August 28, 2025**, restricting access to many previously free images.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides free drop-in replacement images built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a maintained fork of `bitnami/containers`, published to Docker Hub under the `soldevelo/` namespace. Tags are kept in sync with upstream Bitnami.

This PR updates all affected image references in the repository.

## Changed images

- `bitnami/os-shell:12-debian-12-r29` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r33` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r40` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r38` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/redis:6.2.7-debian-11-r3` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/redis:6.2.7-debian-10-r23` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/redis:6.2.6-debian-10-r49` → [`soldevelo/redis:6.2.16-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/os-shell:12-debian-12-r31` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r30` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)